### PR TITLE
Update serviceConsoleCaseTimerWrapperController.js

### DIFF
--- a/aura/serviceConsoleCaseTimerWrapper/serviceConsoleCaseTimerWrapperController.js
+++ b/aura/serviceConsoleCaseTimerWrapper/serviceConsoleCaseTimerWrapperController.js
@@ -8,9 +8,9 @@
         }else{
             component.set('v.pausedVar', true);
         }
-        workspaceAPI.getFocusedTabInfo().then(function(response) {
-            var focusedTabId = response.tabId;            
-            component.set('v.consoleTabId', focusedTabId);
+        workspaceAPI.getEnclosingTabId().then(function(response){
+            var enclosingTabId = response;
+            component.set('v.consoleTabId', enclosingTabId);
             component.set('v.tabFocused', true);
         })
     },


### PR DESCRIPTION
in doInit replaced the workspaceAPI.getFocusedTabInfo() call with workspaceAPI.getEnclosingTabId 
this fixes the issue with not properly pausing / saving Session Times when multiple tabs are opened in parallel.